### PR TITLE
Update facebook marketing time increment spec

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/spec.json
@@ -452,12 +452,20 @@
             },
             "time_increment": {
               "title": "Time Increment",
-              "description": "Time window in days by which to aggregate statistics. The sync will be chunked into N day intervals, where N is the number of days you specified. For example, if you set this value to 7, then all statistics will be reported as 7-day aggregates by starting from the start_date. If the start and end dates are October 1st and October 30th, then the connector will output 5 records: 01 - 06, 07 - 13, 14 - 20, 21 - 27, and 28 - 30 (3 days only). The minimum allowed value for this field is 1, and the maximum is 89.",
-              "default": 1,
-              "maximum": 89,
-              "minimum": 1,
-              "exclusiveMinimum": 0,
-              "type": "integer"
+              "description": "Time window in days by which to aggregate statistics. The sync will be chunked into N day intervals, where N is the number of days you specified. For example, if you set this value to 7, then all statistics will be reported as 7-day aggregates by starting from the start_date. If the start and end dates are October 1st and October 30th, then the connector will output 5 records: 01 - 06, 07 - 13, 14 - 20, 21 - 27, and 28 - 30 (3 days only). The minimum allowed value for this field is 1, and the maximum is 89. Use \"all_days\" to aggregate over the entire date range.",
+              "default": "all_days",
+              "oneOf": [
+                {
+                  "maximum": 89,
+                  "minimum": 1,
+                  "exclusiveMinimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "enum": ["all_days"],
+                  "type": "string"
+                }
+              ]
             },
             "start_date": {
               "title": "Start Date",

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
@@ -123,16 +123,16 @@ class InsightConfig(BaseModel):
         enum=["conversion", "impression", "mixed"],
     )
 
-    time_increment: Optional[PositiveInt] = Field(
+    time_increment: Optional[Union[PositiveInt, Literal["all_days"]]] = Field(
         title="Time Increment",
         description=(
             "Time window in days by which to aggregate statistics. The sync will be chunked into N day intervals, where N is the number of days you specified. "
             "For example, if you set this value to 7, then all statistics will be reported as 7-day aggregates by starting from the start_date. If the start and end dates are October 1st and October 30th, then the connector will output 5 records: 01 - 06, 07 - 13, 14 - 20, 21 - 27, and 28 - 30 (3 days only). "
-            "The minimum allowed value for this field is 1, and the maximum is 89."
+            'The minimum allowed value for this field is 1, and the maximum is 89. Use "all_days" to aggregate over the entire date range.'
         ),
         maximum=89,
         minimum=1,
-        default=1,
+        default="all_days",
     )
 
     start_date: Optional[datetime] = Field(

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -216,7 +216,7 @@ To retrieve specific fields from Facebook Ads Insights combined with other break
 </FieldAnchor>
 
 <FieldAnchor field="custom_insights.time_increment">
-   7. (Optional) For **Time Increment**, you may provide a value in days by which to aggregate statistics. The sync will be chunked into intervals of this size. For example, if you set this value to 7, the sync will be chunked into 7-day intervals. The default value is 1 day.
+   7. (Optional) For **Time Increment**, you may provide a value in days by which to aggregate statistics. The sync will be chunked into intervals of this size. For example, if you set this value to 7, the sync will be chunked into 7-day intervals. You can also set this field to `"all_days"` to aggregate the entire date range into a single interval. The default value is `"all_days"`.
 </FieldAnchor>
 
 <FieldAnchor field="custom_insights.start_date">


### PR DESCRIPTION
## Summary
- allow `"all_days"` string for `time_increment` in the Facebook Marketing source spec
- regenerate integration spec to show `all_days` default
- document the new `"all_days"` option

## Testing
- `pre-commit run --files airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py airbyte-integrations/connectors/source-facebook-marketing/integration_tests/spec.json docs/integrations/sources/facebook-marketing.md`
- `poetry run pytest -k time_increment -q`

------
https://chatgpt.com/codex/tasks/task_b_68435f6a548c83308cb97bfb273870d6