### PR TITLE
feat(facebook-marketing): allow custom cursor/pk

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/integration_tests/spec.json
@@ -500,6 +500,19 @@
               "mininum": 10,
               "exclusiveMinimum": 0,
               "type": "integer"
+            },
+            "cursor_field": {
+              "title": "Cursor Field",
+              "description": "Field to use as the cursor for incremental sync",
+              "default": "date_start",
+              "type": "string"
+            },
+            "primary_key": {
+              "title": "Primary Key Fields",
+              "description": "Fields that uniquely identify records for this insight stream",
+              "default": [],
+              "type": "array",
+              "items": {"type": "string"}
             }
           },
           "required": ["name"]

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
@@ -318,6 +318,8 @@ class SourceFacebookMarketing(AbstractSource):
                 insights_lookback_window=insight.insights_lookback_window or config.insights_lookback_window,
                 insights_job_timeout=insight.insights_job_timeout or config.insights_job_timeout,
                 level=insight.level,
+                cursor_field=insight.cursor_field,
+                primary_key=list(insight.primary_key) if insight.primary_key else None,
             )
             streams.append(stream)
         return streams

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
@@ -167,6 +167,18 @@ class InsightConfig(BaseModel):
         default=60,
     )
 
+    cursor_field: Optional[ValidFields] = Field(
+        title="Cursor Field",
+        description="Field to use as the cursor for incremental sync",
+        default="date_start",
+    )
+
+    primary_key: Optional[List[ValidFields]] = Field(
+        title="Primary Key Fields",
+        description="Fields that uniquely identify records for this insight stream",
+        default=[],
+    )
+
 
 class ConnectorConfig(BaseConfig):
     """Connector config"""

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/base_insight_streams.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/base_insight_streams.py
@@ -77,6 +77,8 @@ class AdsInsights(FBMarketingIncrementalStream):
         insights_lookback_window: int = None,
         insights_job_timeout: int = 60,
         level: str = "ad",
+        cursor_field: Optional[str] = None,
+        primary_key: Optional[List[str]] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -98,6 +100,9 @@ class AdsInsights(FBMarketingIncrementalStream):
         self._insights_job_timeout = insights_job_timeout
         self.level = level
         self.entity_prefix = level
+        if cursor_field:
+            self.cursor_field = cursor_field
+        self._primary_key_override = primary_key
 
         # state
         self._cursor_values: Optional[Mapping[str, pendulum.Date]] = None  # latest period that was read for each account
@@ -113,6 +118,8 @@ class AdsInsights(FBMarketingIncrementalStream):
     @property
     def primary_key(self) -> Optional[Union[str, List[str], List[List[str]]]]:
         """Build complex PK based on slices and breakdowns"""
+        if self._primary_key_override:
+            return self._primary_key_override
 
         breakdowns_pks = []
 

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -231,19 +231,27 @@ To retrieve specific fields from Facebook Ads Insights combined with other break
    10. (Optional) For **Custom Insights Lookback Window**, you may set a window in days to revisit data during syncing to capture updated conversion data from the API. Facebook allows for attribution windows of up to 28 days, during which time a conversion can be attributed to an ad. If you have set a custom attribution window in your Facebook account, please set the same value here. Otherwise, you may leave it at the default value of 28. For more information on action attributions, please refer to [the Meta Help Center](https://www.facebook.com/business/help/458681590974355?id=768381033531365).
 </FieldAnchor>
 
+<FieldAnchor field="custom_insights.cursor_field">
+   11. (Optional) For **Cursor Field**, choose which field should be used to track incremental syncing for this custom insight. The default is `date_start`.
+</FieldAnchor>
+
+<FieldAnchor field="custom_insights.primary_key">
+   12. (Optional) For **Primary Key Fields**, select the fields that uniquely identify records in this custom insight. If left blank, the connector will use `date_start`, `account_id`, and `ad_id` plus any breakdowns.
+</FieldAnchor>
+
 <FieldAnchor field="page_size">
-11. (Optional) For **Page Size of Requests**, you can specify the number of records per page for paginated responses. Most users do not need to set this field unless specific issues arise or there are unique use cases that require tuning the connector's settings. The default value is set to retrieve 100 records per page.
+13. (Optional) For **Page Size of Requests**, you can specify the number of records per page for paginated responses. Most users do not need to set this field unless specific issues arise or there are unique use cases that require tuning the connector's settings. The default value is set to retrieve 100 records per page.
 </FieldAnchor>
 
 <FieldAnchor field="insights_lookback_window">
-12. (Optional) For **Insights Window Lookback**, you may set a window in days to revisit data during syncing to capture updated conversion data from the API. Facebook allows for attribution windows of up to 28 days, during which time a conversion can be attributed to an ad. If you have set a custom attribution window in your Facebook account, please set the same value here. Otherwise, you may leave it at the default value of 28. For more information on action attributions, please refer to [the Meta Help Center](https://www.facebook.com/business/help/458681590974355?id=768381033531365).
+14. (Optional) For **Insights Window Lookback**, you may set a window in days to revisit data during syncing to capture updated conversion data from the API. Facebook allows for attribution windows of up to 28 days, during which time a conversion can be attributed to an ad. If you have set a custom attribution window in your Facebook account, please set the same value here. Otherwise, you may leave it at the default value of 28. For more information on action attributions, please refer to [the Meta Help Center](https://www.facebook.com/business/help/458681590974355?id=768381033531365).
 </FieldAnchor>
 
 <FieldAnchor field="insights_job_timeout">
-13. (Optional) For **Insights Job Timeout**, you may set a custom value in range from 10 to 60. It establishes the maximum amount of time (in minutes) of waiting for the report job to complete.
+15. (Optional) For **Insights Job Timeout**, you may set a custom value in range from 10 to 60. It establishes the maximum amount of time (in minutes) of waiting for the report job to complete.
 </FieldAnchor>
 
-14. Click **Set up source** and wait for the tests to complete.
+16. Click **Set up source** and wait for the tests to complete.
 
 <HideInUI>
 


### PR DESCRIPTION
## Summary
- enable specifying cursor and primary key for custom insights
- document new cursor and primary key options

## Testing
- `ruff check airbyte-integrations/connectors/source-facebook-marketing`
- `poetry run pytest unit_tests` *(fails: No mock address / 9 failed)*

------
https://chatgpt.com/codex/tasks/task_b_68456b3d77d8833097175e63b7ccbcd7